### PR TITLE
Feature #25 custom server port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ requests
 node_modules
 local-run.sh
 *.iml
+.nproject
 
 component_tests/requests
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To run server execute this command
     
 Default port is **4567**
 
-### Command Line Options
+#### Command Line Options
 
 * __-port__: Overwrite default port (4567)
 * __-help__: Show all command line options

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ To run server execute this command
     tshield
     
 Default port is **4567**
-    
+
+### Command Line Options
+
+* __-port__: Overwrite default port (4567)
+* __-help__: Show all command line options
 
 #### Config example
 

--- a/component_tests/matching/examples/simple_path.json
+++ b/component_tests/matching/examples/simple_path.json
@@ -1,0 +1,8 @@
+[{
+  "method": "GET",
+  "path": "/matching/example",
+  "response": {
+    "headers": {},
+    "body": "body content"
+  }
+}]

--- a/features/matching.feature
+++ b/features/matching.feature
@@ -1,0 +1,6 @@
+Feature: Recover response with pattern matching
+  # Work in progress
+  #  Scenario: Return response matching only path
+  #    Given a file to describe "/matching/example" path
+  #    When this path "/matching/example" is accessed throught tshield
+  #    Then response should be equal "matching-example-response"

--- a/features/step_definitions/matching_steps.rb
+++ b/features/step_definitions/matching_steps.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Given('a file to describe {string} path') do |path|
+  @path = path
+end

--- a/lib/tshield/controllers/requests.rb
+++ b/lib/tshield/controllers/requests.rb
@@ -6,7 +6,8 @@ require 'byebug'
 
 require 'tshield/options'
 require 'tshield/configuration'
-require 'tshield/request'
+require 'tshield/request_matching'
+require 'tshield/request_vcr'
 require 'tshield/sessions'
 
 module TShield
@@ -76,7 +77,8 @@ module TShield
 
           set_content_type content_type
 
-          api_response = TShield::Request.new(path, options).response
+          api_response = TShield::RequestMatching.new(path, options).response
+          api_response ||= TShield::RequestVCR.new(path, options).response
 
           logger.info(
             "original=#{api_response.original} method=#{method} path=#{path} content-type=#{request_content_type} session=#{current_session_name(request)}"

--- a/lib/tshield/options.rb
+++ b/lib/tshield/options.rb
@@ -31,6 +31,10 @@ module TShield
       @options.fetch(:configuration_file, 'config/tshield.yml')
     end
 
+    def port
+      @options.fetch(:port, 4567)
+    end
+
     private
 
     def check_breakpoint(args)
@@ -52,6 +56,13 @@ module TShield
       opts.on('-a', '--break-after-request [PATTERN]',
               'Breakpoint after request') do |pattern|
         @options[:after_pattern] = Regexp.new(pattern)
+      end
+    end
+
+    def register_port(opts)
+      opts.on('-p', '--port [PORT]',
+              'Sinatra port') do |port|
+        @options[:port] = port.to_i
       end
     end
 
@@ -92,6 +103,7 @@ module TShield
       register_configuration(opts)
       register_patterns(opts)
       register_version(opts)
+      register_port(opts)
       register_help(opts)
     end
   end

--- a/lib/tshield/request.rb
+++ b/lib/tshield/request.rb
@@ -1,119 +1,21 @@
 # frozen_string_literal: true
 
-require 'httparty'
-require 'json'
-require 'byebug'
-
-require 'digest/sha1'
-
-require 'tshield/configuration'
-require 'tshield/options'
-require 'tshield/response'
 require 'tshield/sessions'
 
 module TShield
+  # Base of request mock methods
   class Request
-    attr_reader :response
+    attr_reader :configuration
+    attr_writer :content_idx
 
-    def initialize(path, options = {})
-      @path = path
-      @options = options
+    def initialize
       @configuration = TShield::Configuration.singleton
-      @options[:timeout] = @configuration.request['timeout']
-      @options[:verify] = @configuration.request['verify_ssl']
-      request
     end
 
-    def request
-      unless @options[:raw_query].nil? || @options[:raw_query].empty?
-        @path = "#{@path}?#{@options[:raw_query]}"
-      end
-
-      @url = "#{domain}#{@path}"
-
-      if exists
-        @response = get_current_response
-        @response.original = false
-      else
-        @method = method
-        @configuration.get_before_filters(domain).each do |filter|
-          @method, @url, @options = filter.new.filter(@method, @url, @options)
-        end
-
-        raw = HTTParty.send(@method.to_s, @url, @options)
-
-        @configuration.get_after_filters(domain).each do |filter|
-          raw = filter.new.filter(raw)
-        end
-
-        @response = save(raw)
-
-        @response.original = true
-      end
-      current_session[:counter].add(@path, method) if current_session
-      debugger if TShield::Options.instance.break?(path: @path, moment: :after)
-      @response
-    end
-
-    private
-
-    def domain
-      @domain ||= @configuration.get_domain_for(@path)
-    end
-
-    def name
-      @name ||= @configuration.get_name(domain)
-    end
-
-    def method
-      @options[:method].downcase
-    end
-
-    def save(raw_response)
-      headers = {}
-      raw_response.headers.each do |k, v|
-        headers[k] = v unless @configuration.not_save_headers(domain).include? k
-      end
-
-      content = {
-        body: raw_response.body,
-        status: raw_response.code,
-        headers: headers
-      }
-
-      write(content)
-
-      TShield::Response.new(raw_response.body, headers, raw_response.code)
-    end
+    protected
 
     def current_session
       TShield::Sessions.current(@options[:ip])
-    end
-
-    def content
-      return @content if @content
-
-      @content = JSON.parse(File.open(destiny).read)
-      @content['body'] = File.open(destiny(true)).read unless @content['body']
-      @content
-    end
-
-    def file_exists
-      session = current_session
-      @content_idx = session ? session[:counter].current(@path, method) : 0
-      File.exist?(destiny)
-    end
-
-    def exists
-      file_exists && @configuration.cache_request?(domain)
-    end
-
-    def get_current_response
-      TShield::Response.new(content['body'], content['headers'] || [], content['status'] || 200)
-    end
-
-    def key
-      @key ||= Digest::SHA1.hexdigest "#{@url}|#{method}"
     end
 
     def session_destiny(request_path)
@@ -147,7 +49,7 @@ module TShield
     end
 
     def clear_path(path)
-      skip_query_params = @configuration.domains[@domain]['skip_query_params']
+      skip_query_params = configuration.domains[@domain]['skip_query_params']
       url_path, params = path.split('?')
 
       return path if !skip_query_params || !params
@@ -157,30 +59,6 @@ module TShield
       end.join('&')
 
       [url_path, cleared_params].join('?')
-    end
-
-    def write(content)
-      f = File.open(destiny(true), 'w')
-      f.write(content[:body])
-      f.close
-
-      body = content.delete :body
-
-      f = File.open(destiny, 'w')
-      f.write(JSON.pretty_generate(content))
-      f.close
-
-      content[:body] = body
-    end
-
-    def safe_dir(url)
-      if url.size > 225
-        path = url.gsub(/(\?.*)/, '')
-        params = Digest::SHA1.hexdigest Regexp.last_match(1)
-        "#{path.gsub(%r{/}, '-').gsub(/^-/, '')}?#{params}"
-      else
-        url.gsub(%r{/}, '-').gsub(/^-/, '')
-      end
     end
   end
 end

--- a/lib/tshield/request.rb
+++ b/lib/tshield/request.rb
@@ -26,7 +26,15 @@ module TShield
       Dir.mkdir(request_path) unless File.exist?(request_path)
     end
 
-    def destiny(iscontent = false)
+    def content_destiny
+      "#{destiny}.content"
+    end
+
+    def headers_destiny
+      "#{destiny}.json"
+    end
+
+    def destiny
       request_path = File.join('requests')
       Dir.mkdir(request_path) unless File.exist?(request_path)
 
@@ -43,9 +51,7 @@ module TShield
       method_path = File.join(path_path, method)
       Dir.mkdir(method_path) unless File.exist?(method_path)
 
-      destiny_name = iscontent ? "#{@content_idx}.content" : "#{@content_idx}.json"
-
-      File.join(method_path, destiny_name)
+      File.join(method_path, @content_idx.to_s)
     end
 
     def clear_path(path)
@@ -59,6 +65,10 @@ module TShield
       end.join('&')
 
       [url_path, cleared_params].join('?')
+    end
+
+    def method
+      @options[:method].downcase
     end
   end
 end

--- a/lib/tshield/request_matching.rb
+++ b/lib/tshield/request_matching.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'tshield/request'
+
+module TShield
+  # Class to check request matching
+  class RequestMatching
+  end
+end

--- a/lib/tshield/request_matching.rb
+++ b/lib/tshield/request_matching.rb
@@ -5,5 +5,36 @@ require 'tshield/request'
 module TShield
   # Class to check request matching
   class RequestMatching
+    attr_reader :response
+
+    def initialize(path, options = {})
+      super()
+      @path = path
+      @options = options
+
+      self.class.load_stubs unless self.class.stubs
+
+      match_request
+    end
+
+    def match_request; end
+
+    class << self
+      attr_reader :stubs
+      def load_stubs
+        @stubs = {}
+        Dir.glob('matching/**/*.json').each do |entry|
+          load_stub(entry)
+        end
+      end
+
+      def load_stub(file)
+        content = JSON.parse File.open(file).read
+        content.each do |item|
+          @stubs[item['path']] ||= []
+          @stubs[item['path']] << item
+        end
+      end
+    end
   end
 end

--- a/lib/tshield/request_vcr.rb
+++ b/lib/tshield/request_vcr.rb
@@ -35,7 +35,7 @@ module TShield
       @url = "#{domain}#{@path}"
 
       if exists
-        @response = get_current_response
+        @response = current_response
         @response.original = false
       else
         @method = method
@@ -68,10 +68,6 @@ module TShield
       @name ||= configuration.get_name(domain)
     end
 
-    def method
-      @options[:method].downcase
-    end
-
     def save(raw_response)
       headers = {}
       raw_response.headers.each do |k, v|
@@ -89,26 +85,28 @@ module TShield
       TShield::Response.new(raw_response.body, headers, raw_response.code)
     end
 
-    def content
-      return @content if @content
+    def saved_content
+      return @saved_content if @saved_content
 
-      @content = JSON.parse(File.open(destiny).read)
-      @content['body'] = File.open(destiny(true)).read unless @content['body']
-      @content
+      @saved_content = JSON.parse(File.open(headers_destiny).read)
+      @saved_content['body'] = File.open(content_destiny).read unless @saved_content['body']
+      @saved_content
     end
 
     def file_exists
       session = current_session
       @content_idx = session ? session[:counter].current(@path, method) : 0
-      File.exist?(destiny)
+      File.exist?(content_destiny)
     end
 
     def exists
       file_exists && configuration.cache_request?(domain)
     end
 
-    def get_current_response
-      TShield::Response.new(content['body'], content['headers'] || [], content['status'] || 200)
+    def current_response
+      TShield::Response.new(saved_content['body'],
+                            saved_content['headers'] || [],
+                            saved_content['status'] || 200)
     end
 
     def key
@@ -116,15 +114,15 @@ module TShield
     end
 
     def write(content)
-      f = File.open(destiny(true), 'w')
-      f.write(content[:body])
-      f.close
+      content_file = File.open(content_destiny, 'w')
+      content_file.write(content[:body])
+      content_file.close
 
       body = content.delete :body
 
-      f = File.open(destiny, 'w')
-      f.write(JSON.pretty_generate(content))
-      f.close
+      headers_file = File.open(headers_destiny, 'w')
+      headers_file.write(JSON.pretty_generate(content))
+      headers_file.close
 
       content[:body] = body
     end

--- a/lib/tshield/request_vcr.rb
+++ b/lib/tshield/request_vcr.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'httparty'
+require 'json'
+require 'byebug'
+
+require 'digest/sha1'
+
+require 'tshield/configuration'
+require 'tshield/options'
+require 'tshield/request'
+require 'tshield/response'
+
+module TShield
+  # Module to write and read saved responses
+  class RequestVCR < TShield::Request
+    attr_reader :response
+
+    def initialize(path, options = {})
+      super()
+      @path = path
+      @options = options
+
+      request_configuration = configuration.request
+      @options[:timeout] = request_configuration['timeout']
+      @options[:verify] = request_configuration['verify_ssl']
+      request
+    end
+
+    def request
+      unless @options[:raw_query].nil? || @options[:raw_query].empty?
+        @path = "#{@path}?#{@options[:raw_query]}"
+      end
+
+      @url = "#{domain}#{@path}"
+
+      if exists
+        @response = get_current_response
+        @response.original = false
+      else
+        @method = method
+        configuration.get_before_filters(domain).each do |filter|
+          @method, @url, @options = filter.new.filter(@method, @url, @options)
+        end
+
+        raw = HTTParty.send(@method.to_s, @url, @options)
+
+        configuration.get_after_filters(domain).each do |filter|
+          raw = filter.new.filter(raw)
+        end
+
+        @response = save(raw)
+
+        @response.original = true
+      end
+      current_session[:counter].add(@path, method) if current_session
+      debugger if TShield::Options.instance.break?(path: @path, moment: :after)
+      @response
+    end
+
+    private
+
+    def domain
+      @domain ||= configuration.get_domain_for(@path)
+    end
+
+    def name
+      @name ||= configuration.get_name(domain)
+    end
+
+    def method
+      @options[:method].downcase
+    end
+
+    def save(raw_response)
+      headers = {}
+      raw_response.headers.each do |k, v|
+        headers[k] = v unless configuration.not_save_headers(domain).include? k
+      end
+
+      content = {
+        body: raw_response.body,
+        status: raw_response.code,
+        headers: headers
+      }
+
+      write(content)
+
+      TShield::Response.new(raw_response.body, headers, raw_response.code)
+    end
+
+    def content
+      return @content if @content
+
+      @content = JSON.parse(File.open(destiny).read)
+      @content['body'] = File.open(destiny(true)).read unless @content['body']
+      @content
+    end
+
+    def file_exists
+      session = current_session
+      @content_idx = session ? session[:counter].current(@path, method) : 0
+      File.exist?(destiny)
+    end
+
+    def exists
+      file_exists && configuration.cache_request?(domain)
+    end
+
+    def get_current_response
+      TShield::Response.new(content['body'], content['headers'] || [], content['status'] || 200)
+    end
+
+    def key
+      @key ||= Digest::SHA1.hexdigest "#{@url}|#{method}"
+    end
+
+    def write(content)
+      f = File.open(destiny(true), 'w')
+      f.write(content[:body])
+      f.close
+
+      body = content.delete :body
+
+      f = File.open(destiny, 'w')
+      f.write(JSON.pretty_generate(content))
+      f.close
+
+      content[:body] = body
+    end
+
+    def safe_dir(url)
+      if url.size > 225
+        path = url.gsub(/(\?.*)/, '')
+        params = Digest::SHA1.hexdigest Regexp.last_match(1)
+        "#{path.gsub(%r{/}, '-').gsub(/^-/, '')}?#{params}"
+      else
+        url.gsub(%r{/}, '-').gsub(/^-/, '')
+      end
+    end
+  end
+end

--- a/lib/tshield/server.rb
+++ b/lib/tshield/server.rb
@@ -3,6 +3,7 @@
 require 'sinatra'
 require 'haml'
 
+require 'tshield/options'
 require 'tshield/controllers/requests'
 require 'tshield/controllers/sessions'
 
@@ -15,6 +16,7 @@ module TShield
     set :public_dir, File.join(File.dirname(__FILE__), 'assets')
     set :views, File.join(File.dirname(__FILE__), 'views')
     set :bind, '0.0.0.0'
+    set :port, TShield::Options.instance.port
 
     def self.register_resources
       load_controllers
@@ -26,8 +28,6 @@ module TShield
       return unless File.exist?('controllers')
 
       Dir.entries('controllers').each do |entry|
-        require 'byebug'
-        debugger
         next if entry =~ /^\.\.?$/
 
         entry.gsub!('.rb', '')

--- a/spec/tshield/fixtures/patterns/example.json
+++ b/spec/tshield/fixtures/patterns/example.json
@@ -1,0 +1,8 @@
+[{
+  "method": "GET",
+  "path": "/matching/example",
+  "response": {
+    "headers": {},
+    body: "body content"
+  }
+}]

--- a/spec/tshield/options_spec.rb
+++ b/spec/tshield/options_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: false
+
+require 'optparse'
+require 'tshield/options'
+require 'spec_helper'
+
+describe TShield::Options do
+  context 'with parsing' do
+    before :each do
+      options_parser = double
+      @opts = double
+
+      allow(OptionParser).to receive(:new)
+        .and_return(options_parser)
+        .and_yield(@opts)
+
+      allow(options_parser).to receive(:parse!)
+
+      allow(@opts).to receive(:banner=)
+      allow(@opts).to receive(:on)
+      allow(@opts).to receive(:on_tail)
+    end
+
+    it 'should recover default port' do
+      TShield::Options.init
+      expect(TShield::Options.instance.port).to eql(4567)
+    end
+
+    it 'should recover custom port' do
+      allow(@opts).to receive(:on)
+        .with('-p', '--port [PORT]', 'Sinatra port')
+        .and_yield('4568')
+
+      TShield::Options.init
+      expect(TShield::Options.instance.port).to eql(4568)
+    end
+  end
+end

--- a/spec/tshield/request_matching_spec.rb
+++ b/spec/tshield/request_matching_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'tshield/request_matching'
+
+describe TShield::RequestMatching do
+  before :each do
+    @configuration = double
+    allow(TShield::Configuration)
+      .to receive(:singleton).and_return(@configuration)
+  end
+
+  context 'matching path' do
+  end
+end

--- a/spec/tshield/request_vcr_spec.rb
+++ b/spec/tshield/request_vcr_spec.rb
@@ -53,11 +53,8 @@ describe TShield::RequestVCR do
           .with('./requests/example.org/?allowed=true', 'get')
           .and_return('./requests/example.org/?allowed=true/get')
         allow(File).to receive(:join)
-          .with('./requests/example.org/?allowed=true/get', '0.json')
-          .and_return('./requests/example.org/?allowed=true/get/0.json')
-        allow(File).to receive(:join)
-          .with('./requests/example.org/?allowed=true/get', '0.content')
-          .and_return('./requests/example.org/?allowed=true/get/0.content')
+          .with('./requests/example.org/?allowed=true/get', '0')
+          .and_return('./requests/example.org/?allowed=true/get/0')
 
         allow(@configuration).to receive(:domains).and_return(
           'example.org' => {

--- a/spec/tshield/request_vcr_spec.rb
+++ b/spec/tshield/request_vcr_spec.rb
@@ -2,9 +2,9 @@
 
 require 'spec_helper'
 
-require 'tshield/request'
+require 'tshield/request_vcr'
 
-describe TShield::Request do
+describe TShield::RequestVCR do
   before :each do
     @configuration = double
     allow(TShield::Configuration)
@@ -18,9 +18,9 @@ describe TShield::Request do
 
   describe 'when save response' do
     it 'should write response body, request status and headers' do
-      allow_any_instance_of(TShield::Request).to receive(:exists)
+      allow_any_instance_of(TShield::RequestVCR).to receive(:exists)
         .and_return(false)
-      allow_any_instance_of(TShield::Request).to receive(:destiny)
+      allow_any_instance_of(TShield::RequestVCR).to receive(:destiny)
       allow(HTTParty).to receive(:send).and_return(RawResponse.new)
 
       write_spy = double
@@ -32,7 +32,7 @@ describe TShield::Request do
         .with("{\n  \"status\": 200,\n  \"headers\": {\n  }\n}")
       allow(write_spy).to receive(:close)
 
-      TShield::Request.new '/', method: 'GET'
+      TShield::RequestVCR.new '/', method: 'GET'
     end
 
     describe 'and query params exists in list to skip' do
@@ -81,9 +81,9 @@ describe TShield::Request do
         expect(file_double).to receive(:close)
         expect(file_double).to receive(:close)
 
-        TShield::Request.new '/',
-                             raw_query: 'allowed=true&skipped=1',
-                             method: 'GET'
+        TShield::RequestVCR.new '/',
+                                raw_query: 'allowed=true&skipped=1',
+                                method: 'GET'
       end
     end
   end


### PR DESCRIPTION
## Description

Adding command line parameter to set sinatra port.

Closes #25 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [x] New feature
- [x] This change requires a documentation update

## How Has This Been Tested?
When this new parameter is not given TShield starts with default Sinatra port (4567).
Unit tests were created to cover this new parameter.
