### PR TITLE
Change server to puma

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tshield (0.11.13.0)
+    tshield (0.11.14.0)
       byebug (~> 11.0, >= 11.0.1)
       httparty (~> 0.14, >= 0.14.0)
       json (~> 2.0, >= 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       byebug (~> 11.0, >= 11.0.1)
       httparty (~> 0.14, >= 0.14.0)
       json (~> 2.0, >= 2.0)
+      puma (~> 4.3, >= 4.3.3)
       sinatra (~> 1.4, >= 1.4.0)
       sinatra-cross_origin (~> 0.4.0, >= 0.4)
 
@@ -20,7 +21,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     backports (3.15.0)
     builder (3.2.3)
-    byebug (11.1.1)
+    byebug (11.1.3)
     codeclimate-engine-rb (0.4.1)
       virtus (~> 1.0)
     coderay (1.1.2)
@@ -93,6 +94,7 @@ GEM
     multi_test (0.1.2)
     multi_xml (0.6.0)
     nenv (0.3.0)
+    nio4r (2.5.2)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -104,6 +106,8 @@ GEM
       method_source (~> 0.9.0)
     psych (3.1.0)
     public_suffix (3.0.3)
+    puma (4.3.3)
+      nio4r (~> 2.0)
     rack (1.6.12)
     rack-protection (1.5.5)
       rack

--- a/lib/tshield/server.rb
+++ b/lib/tshield/server.rb
@@ -17,6 +17,7 @@ module TShield
     set :views, File.join(File.dirname(__FILE__), 'views')
     set :bind, '0.0.0.0'
     set :port, TShield::Options.instance.port
+    set :server, :puma
 
     configure do
       enable :cross_origin

--- a/lib/tshield/version.rb
+++ b/lib/tshield/version.rb
@@ -5,7 +5,7 @@ module TShield
   class Version
     MAJOR = 0
     MINOR = 11
-    PATCH = 13
+    PATCH = 14
     PRE = 0
 
     class << self

--- a/tshield.gemspec
+++ b/tshield.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency('byebug', '~> 11.0', '>= 11.0.1')
   s.add_dependency('httparty', '~> 0.14', '>= 0.14.0')
   s.add_dependency('json', '~> 2.0', '>= 2.0')
+  s.add_dependency('puma', '~> 4.3', '>= 4.3.3')
   s.add_dependency('sinatra', '~> 1.4', '>= 1.4.0')
   s.add_dependency('sinatra-cross_origin', '~> 0.4.0', '>= 0.4')
   s.add_development_dependency('coveralls')


### PR DESCRIPTION
## Description

Changing Sinatra to use Puma as webserver (instead of WEBrick). 
The Webrick was returning status code 411 (WEBrick::HTTPStatus::LengthRequired) in some requests.

- [x] Bug fix

PS: The existing tests is far enough to cover this fix.