### PR TITLE
Adding option to set response delay by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Optional request attributes:
 this stub will be returned if all headers are in request. 
 *   **query**: works like headers but use query params.
 
+Optional response attributes:
+
+*   **delay**: integer that represents time in seconds that the response will be delayed to return
+
 **Important**: If VCR config conflicts with Matching config Matching will be
 used. Matching config have priority.
 
@@ -166,6 +170,7 @@ To register stub into a session create an object with following attributes:
       "method": "GET",
       "path": "/matching/example",
       "response": {
+        "delay": 5,
         "body": "matching-example-response-in-session",
         "headers": {},
         "status": 200
@@ -206,6 +211,8 @@ domains:
       - transfer-encoding
     paths:
       - /secure
+    delay:
+      '/secure': 10
 
   'http://localhost:9092':
     name: 'my-other-service'
@@ -216,6 +223,8 @@ domains:
       - transfer-encoding
     paths:
       - /users
+    delay:
+      '/users': 5
 ```
 **request**
 *   **timeout**: wait time for real service in seconds
@@ -231,6 +240,7 @@ domains:
 *   **filters**: Implementation of before or after filters used in domain requests
 *   **excluded_headers**: <<some_description>>
 *   **paths**: Paths list of all services that will be called. Used to filter what domain will "receive the request"
+*   **delay**: List of times in seconds that the response will be delayed to return for an specific path defined above
 
 ## Manage Sessions
 

--- a/component_tests/config.yml
+++ b/component_tests/config.yml
@@ -18,3 +18,7 @@ domains:
       - /users
       - /resources
       - /conflicts/path
+      - /delay
+    delay:
+      '/delay': 10
+    

--- a/component_tests/matching/examples/delay_session.json
+++ b/component_tests/matching/examples/delay_session.json
@@ -1,0 +1,28 @@
+[
+  {
+    "session": "example-session-with-delay",
+    "stubs": [{
+      "method": "GET",
+      "path": "/matching/delay",
+      "response": {
+        "delay": 10,
+        "status": 200,
+        "headers": {},
+        "body": "matching-example-response-in-session-with-delay"
+      }
+    }]
+  },
+  {
+    "session": "example-session-without-delay",
+    "stubs": [{
+      "method": "GET",
+      "path": "/matching/without/delay",
+      "response": {
+        "delay": 0,
+        "status": 200,
+        "headers": {},
+        "body": "matching-example-response-in-session-without-delay"
+      }
+    }]
+  }
+]

--- a/component_tests/server.rb
+++ b/component_tests/server.rb
@@ -18,4 +18,15 @@ get '/conflicts/path' do
   'vcr'
 end
 
+get '/delay' do
+  [{
+    name: 'name'
+  }].to_json
+end
+
+get '/without/delay' do
+  [{
+    name: 'name'
+  }].to_json
+end
 set :port, 9090

--- a/component_tests/windows_compatibility.yml
+++ b/component_tests/windows_compatibility.yml
@@ -19,6 +19,3 @@ domains:
       - /users
       - /resources
       - /conflicts/path
-      - /delay
-    delay:
-      '/matching/delay': 10

--- a/component_tests/windows_compatibility.yml
+++ b/component_tests/windows_compatibility.yml
@@ -19,3 +19,6 @@ domains:
       - /users
       - /resources
       - /conflicts/path
+      - /delay
+    delay:
+      '/matching/delay': 10

--- a/features/matching-with-session.feature
+++ b/features/matching-with-session.feature
@@ -45,3 +45,17 @@ Feature: Group stubs into sessions
     And append session "second-session"
     And this path "/matching/second-fake" is accessed throught tshield 2 times
     Then call number 2 response should be equal "secondary-session-second-response-fake"
+  
+  Scenario: Return response matching with delay when is defined
+    Given a file to describe "/matching/delay" path
+    And in session "example-session-with-delay"
+    When this path "/matching/delay" is accessed throught tshield
+    Then response should delay "more" than 10 seconds
+    And response should be equal "matching-example-response-in-session-with-delay"
+  
+  Scenario: Return response matching without delay when is not defined
+    Given a file to describe "/matching/without/delay" path
+    And in session "example-session-without-delay"
+    When this path "/matching/without/delay" is accessed throught tshield
+    Then response should delay "less" than 1 seconds
+    And response should be equal "matching-example-response-in-session-without-delay"

--- a/features/step_definitions/vcr_steps.rb
+++ b/features/step_definitions/vcr_steps.rb
@@ -21,6 +21,7 @@ Given('saved vcr session called {string}') do |session_name|
 end
 
 When('this api is accessed throught tshield') do
+  @time = Time.now
   HTTParty.get(TShieldHelpers.tshield_url(@path))
 end
 
@@ -29,6 +30,7 @@ When('this api is accessed throught tshield with param {string} and value {strin
 end
 
 When('this path {string} is accessed throught tshield') do |path|
+  @time = Time.now
   @response = HTTParty.get(TShieldHelpers.tshield_url(path))
 end
 
@@ -47,6 +49,15 @@ Then('response should be saved in directory {string}') do |directory|
     next if entry !~ /resources/
 
     expect(entry).to eql(directory)
+  end
+end
+
+Then('response should delay {string} than {int} seconds') do |operation, content|
+  @time = Time.now - @time
+  if operation == 'more'
+    expect(@time).to be >= content
+  else
+    expect(@time).to be < content
   end
 end
 

--- a/features/vcr-with-session.feature
+++ b/features/vcr-with-session.feature
@@ -41,3 +41,17 @@ Feature: Save request on first call and returns saved on second grouped by sessi
     And this api is accessed throught tshield with param "t" and value "saved-in-main-session"
     And this api is accessed throught tshield with param "t" and value "saved-in-second-session"
     Then should get response saved into session "second-session"
+
+  Scenario: Response with delay when is defined
+    Given a valid api "/delay"
+    And in session "delay-session"
+    When this api is accessed throught tshield
+    Then response should delay "more" than 10 seconds
+    And response should be saved in "delay/get/0.content" in session "delay-session"
+  
+  Scenario: Response without delay when is not defined
+    Given a valid api "/without/delay"
+    And in session "delay-session"
+    When this api is accessed throught tshield
+    Then response should delay "less" than 1 seconds
+    And response should be saved in "without-delay/get/0.content" in session "delay-session"

--- a/lib/tshield/configuration.rb
+++ b/lib/tshield/configuration.rb
@@ -131,5 +131,10 @@ module TShield
       )
       raise 'Startup aborted'
     end
+
+    def get_delay(domain, path)
+      ((domains[domain] || {})['delay'] || {})[path] || 0
+    end
+
   end
 end

--- a/lib/tshield/controllers/requests.rb
+++ b/lib/tshield/controllers/requests.rb
@@ -74,7 +74,7 @@ module TShield
               configuration.get_excluded_headers(domain(path)).include?(key)
             end
           end
-
+          
           logger.info(
             "original=#{api_response.original} method=#{method} path=#{path} "\
             "content-type=#{request_content_type} "\
@@ -82,6 +82,7 @@ module TShield
           )
           TShield::Controllers::Helpers::SessionHelpers.update_session_call(request, callid, method)
 
+          delay(path)
           status api_response.status
           headers api_response.headers
           body api_response.body
@@ -100,6 +101,13 @@ module TShield
         def domain(path)
           @domain ||= configuration.get_domain_for(path)
         end
+
+        def delay(path)
+          delay_in_seconds = configuration.get_delay(domain(path), path) || 0
+          logger.info("Response with delay of #{delay_in_seconds} seconds")
+          sleep delay_in_seconds
+        end
+
       end
     end
   end

--- a/lib/tshield/request_matching.rb
+++ b/lib/tshield/request_matching.rb
@@ -29,6 +29,7 @@ module TShield
 
       @matched = current_response
 
+      sleep matched['delay'] || 0
       TShield::Response.new(self.class.read_body(matched['body']),
                             matched['headers'],
                             matched['status'])


### PR DESCRIPTION
## Description

This change add the option to set response delay to any path configured in the config.yml. This feature will help developers to test slow scenarios, as instance, when a loading appears in the screen and disappears when receive the response, the loading could be tested setting a delay to the specific path response.

Fixes # (bug issue)
Closes # (feature issue)

## Type of change

Please delete options that are not relevant.

*   [ ] Bug fix
*   [X] New feature
*   [ ] This change requires a documentation update

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Was created 4 component tests scenarios to validate VCR and matching delay config. Two scenarios have been configured with 10 seconds delay and it's expected that the response returns at least after 10 seconds and for the others have been configured with 0 seconds delay and it's expected to response immediately.