### PR TITLE
make save_request and save_response being called at different moments

### DIFF
--- a/component_tests/run
+++ b/component_tests/run
@@ -28,7 +28,7 @@ export STATUS_GRPC_ON="$?"
 echo "killing server($SERVER) server($GRPC_SERVER)"
 kill $SERVER $GRPC_SERVER
 
-if [ $STATUS_GRPC_ON = '0' ] && [ $STATUS_GRPC_ON = '0' ]; then
+if [ $STATUS_GRPC_ON = '0' ] && [ $STATUS_GRPC_OFF = '0' ]; then
   exit '0'
 else
   exit '1'

--- a/component_tests/run
+++ b/component_tests/run
@@ -4,6 +4,16 @@ cd component_tests
 ruby server.rb &
 SERVER=$!
 
+../bin/tshield -c config.yml &
+
+sleep 5
+
+cd ..
+echo "Runing tests with GRPC Server down"
+cucumber --tags @grpc_service_off
+export STATUS_GRPC_OFF="$?"
+
+cd component_tests
 ruby grpc_server.rb &
 GRPC_SERVER=$!
 
@@ -12,10 +22,14 @@ GRPC_SERVER=$!
 sleep 5
 
 cd ..
-cucumber
-export STATUS="$?"
+cucumber --tags "not @grpc_service_off"
+export STATUS_GRPC_ON="$?"
 
 echo "killing server($SERVER) server($GRPC_SERVER)"
 kill $SERVER $GRPC_SERVER
 
-exit $STATUS
+if [ $STATUS_GRPC_ON = '0' ] && [ $STATUS_GRPC_ON = '0' ]; then
+  exit '0'
+else
+  exit '1'
+fi

--- a/features/grpc-vcr.feature
+++ b/features/grpc-vcr.feature
@@ -10,3 +10,11 @@ Feature: Save response on call real grpc and return on second call
     And in session "vcr-session"
     When this method called throught tshield with request "Helloworld::HelloRequest"
     Then grpc response should be saved in "requests/grpc/vcr-session/Helloworld::Greeter/say_hello/5759534c6594b9eb7a22bbb40ba8d6c887a7e3f0"
+
+@grpc_service_off
+  Scenario: Save only original_request in a session when GRPC service is unavailable
+    Given a valid gRPC method "say_hello" defined in "Helloworld::Greeter"
+    And in session "vcr-session"
+    When this method called throught tshield with request "Helloworld::HelloRequest" expecting an connection error
+    Then grpc original_request file should be saved in "requests/grpc/vcr-session/Helloworld::Greeter/say_hello/5759534c6594b9eb7a22bbb40ba8d6c887a7e3f0"
+    But grpc response file should not be saved in "requests/grpc/vcr-session/Helloworld::Greeter/say_hello/5759534c6594b9eb7a22bbb40ba8d6c887a7e3f0"

--- a/features/step_definitions/grpc_steps.rb
+++ b/features/step_definitions/grpc_steps.rb
@@ -11,6 +11,15 @@ When('this method called throught tshield with request {string}') do |request_ty
   @service_instance.send(@method.to_sym, request_instance)
 end
 
+When('this method called throught tshield with request {string} expecting an connection error') do |request_type|
+  puts Kernel.const_get(request_type.to_s)
+  request_instance = Kernel.const_get(request_type.to_s).new(GrpcHelpers.example_request)
+
+  expect {
+    require @service_instance.send(@method.to_sym, request_instance)
+  }.to raise_error(/14:failed to connect to all addresses./)
+end
+
 Then('grpc response should be saved in {string}') do |directory|
   directory = File.join './component_tests', directory
   request_file = JSON.parse(File.read(File.join(directory, 'original_request')))
@@ -21,3 +30,17 @@ Then('grpc response should be saved in {string}') do |directory|
   expect(response_class_file).to eql('Helloworld::HelloReply')
   expect(request_file).to eql(GrpcHelpers.example_request)
 end
+
+Then('grpc original_request file should be saved in {string}') do |directory|
+  directory = File.join './component_tests', directory
+  request_file = JSON.parse(File.read(File.join(directory, 'original_request')))
+
+  expect(request_file).to eql(GrpcHelpers.example_request)
+end
+
+Then('grpc response file should not be saved in {string}') do |directory|
+  directory = File.join './component_tests', directory
+  expect {File.read(File.join(directory, 'response'))}.to raise_error(/No such file or directory/)
+  expect {File.read(File.join(directory, 'response_class'))}.to raise_error(/No such file or directory/)
+end
+

--- a/lib/tshield/grpc/vcr.rb
+++ b/lib/tshield/grpc/vcr.rb
@@ -16,6 +16,7 @@ module TShield
         module_name = options['module']
 
         path = create_destiny(module_name, method_name, request)
+        save_request(path, request)
         response = saved_response(path)
         if response
           TShield.logger.info("returning saved response for request #{request.to_json} saved into #{hexdigest(request)}")
@@ -26,7 +27,7 @@ module TShield
         client_class = Object.const_get("#{module_name}::Stub")
         client_instance = client_class.new(options['hostname'], :this_channel_is_insecure)
         response = client_instance.send(method_name, request)
-        save_request_and_response(path, request, response)
+        save_response(path, response)
         response
       end
 
@@ -37,11 +38,6 @@ module TShield
         content = JSON.parse File.open(response_file).read
         response_class = File.open(File.join(path, 'response_class')).read.strip
         Kernel.const_get(response_class).new(content)
-      end
-
-      def save_request_and_response(path, request, response)
-        save_request(path, request)
-        save_response(path, response)
       end
 
       def save_request(path, request)


### PR DESCRIPTION
## Description

Doing this rearrangement tshield would always generate the original_request from my API and I would be able to test what data my API is generating without needing to create any mock.

## Type of change
Minor - Code rearrangement

## How Has This Been Tested
As this is just a rearrangement of the code I used the existing tests to validate if everything is working properly 
