### PR TITLE
Bugfix/preflight headers and store multiple cookies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tshield (0.13.1.0)
+    tshield (0.13.2.0)
       grpc (~> 1.28, >= 1.28.0)
       grpc-tools (~> 1.28, >= 1.28.0)
       httparty (~> 0.14, >= 0.14.0)
@@ -205,4 +205,4 @@ DEPENDENCIES
   webmock (~> 2.1, >= 2.1.0)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/lib/tshield/request_vcr.rb
+++ b/lib/tshield/request_vcr.rb
@@ -78,11 +78,30 @@ module TShield
       @method ||= @options[:method].downcase
     end
 
+    def apply_set_cookie_header_values(raw_response, headers = {})
+
+      headers_clone = headers.clone
+
+      field = raw_response.get_fields('Set-Cookie')
+
+      if !field.nil? && !field.empty?
+        cookies_values = []
+        field.each { |value| cookies_values.push(value) }
+        headers_clone['Set-Cookie'] = cookies_values
+      end
+
+      headers_clone
+    end
+
     def save(raw_response)
       headers = {}
+
       raw_response.headers.each do |k, v|
+        next if k == 'set-cookie'
         headers[k] = v unless configuration.not_save_headers(domain).include? k
       end
+
+      headers = apply_set_cookie_header_values(raw_response, headers)
 
       content = {
         body: raw_response.body,

--- a/lib/tshield/server.rb
+++ b/lib/tshield/server.rb
@@ -29,9 +29,9 @@ module TShield
 
     options '*' do
       response.headers['Allow'] = 'GET, PUT, POST, DELETE, OPTIONS'
-      response.headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type,
-                                                        Accept, X-User-Email, X-Auth-Token'
+      response.headers['Access-Control-Allow-Headers'] = '*'
       response.headers['Access-Control-Allow-Origin'] = '*'
+      response.headers['Access-Control-Allow-Methods'] = '*'
       200
     end
 

--- a/lib/tshield/version.rb
+++ b/lib/tshield/version.rb
@@ -5,7 +5,7 @@ module TShield
   class Version
     MAJOR = 0
     MINOR = 13
-    PATCH = 1
+    PATCH = 2
     PRE = 0
 
     class << self

--- a/spec/tshield/request_vcr_spec.rb
+++ b/spec/tshield/request_vcr_spec.rb
@@ -10,6 +10,7 @@ describe TShield::RequestVCR do
     allow(TShield::Configuration)
       .to receive(:singleton).and_return(@configuration)
     allow(@configuration).to receive(:get_before_filters).and_return([])
+    allow(@configuration).to receive(:not_save_headers).and_return([])
     allow(@configuration).to receive(:get_after_filters).and_return([])
     allow(@configuration).to receive(:request).and_return('timeout' => 10)
     allow(@configuration).to receive(:get_domain_for).and_return('example.org')
@@ -30,6 +31,24 @@ describe TShield::RequestVCR do
       expect(write_spy).to receive(:write)
         .ordered
         .with("{\n  \"status\": 200,\n  \"headers\": {\n  }\n}")
+      allow(write_spy).to receive(:close)
+
+      TShield::RequestVCR.new '/', method: 'GET'
+    end
+
+    it 'should write response headers as multiple occcurences when has more than one with same key' do
+      allow_any_instance_of(TShield::RequestVCR).to receive(:exists)
+        .and_return(false)
+      allow_any_instance_of(TShield::RequestVCR).to receive(:destiny)
+      allow(HTTParty).to receive(:send).and_return(RawResponseCookiesMultipleValues.new)
+
+      write_spy = double
+      allow(File).to receive(:open).and_return(write_spy)
+
+      expect(write_spy).to receive(:write).ordered.with('this is the body')
+      expect(write_spy).to receive(:write)
+        .ordered
+        .with("{\n  \"status\": 200,\n  \"headers\": {\n    \"Set-Cookie\": [\n      \"FirstCookie=An Value\",\n      \"SecondCookie=An Value\"\n    ]\n  }\n}")
       allow(write_spy).to receive(:close)
 
       TShield::RequestVCR.new '/', method: 'GET'
@@ -144,8 +163,33 @@ describe TShield::RequestVCR do
       'this is the body'
     end
 
+    def get_fields(field = "")
+      []
+    end
+
     def code
       200
     end
   end
+
+  class RawResponseCookiesMultipleValues
+    def headers
+     {'Set-Cookie' => ['FirstCookie=An Value', 'SecondCookie=An Value']}
+    end
+
+    def body
+      'this is the body'
+    end
+
+    def get_fields(field = "")
+      self.headers[filed] unless self.headers.key?(field)
+    end
+
+    def code
+      200
+    end
+  end
+
 end
+
+


### PR DESCRIPTION
## Description

Fixes restrictions on 'Access-Control-Allow-Headers' and 'Access-Control-Allow-Methods', due the preflight behavior. 

Fixes #70
Fixes #71 

## Type of change

Please delete options that are not relevant.

*   [x] Bug fix
