### PR TITLE
Adding new property under domains to not send Header Content-Type application/json when applicable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tshield (0.13.2.0)
+    tshield (0.13.3.0)
       grpc (~> 1.28, >= 1.28.0)
       grpc-tools (~> 1.28, >= 1.28.0)
       httparty (~> 0.14, >= 0.14.0)
@@ -58,10 +58,10 @@ GEM
     ffi (1.13.1)
     formatador (0.2.5)
     gherkin (5.1.0)
-    google-protobuf (3.14.0)
+    google-protobuf (3.14.0-x86_64-linux)
     googleapis-common-protos-types (1.0.5)
       google-protobuf (~> 3.11)
-    grpc (1.34.0)
+    grpc (1.34.0-x86_64-linux)
       google-protobuf (~> 3.13)
       googleapis-common-protos-types (~> 1.0)
     grpc-tools (1.34.0)
@@ -205,4 +205,4 @@ DEPENDENCIES
   webmock (~> 2.1, >= 2.1.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.11

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ domains:
     headers:
       HTTP_AUTHORIZATION: Authorization
       HTTP_COOKIE: Cookie
+    send_header_content_type: true  
     not_save_headers:
       - transfer-encoding
     cache_request: <<value>>
@@ -235,6 +236,7 @@ domains:
 *   Define Base URI of service
 *   **name**: Name to identify the domain in the generated files
 *   **headers**: github-issue #17
+*   **send_header_content_type**: Boolean domain config to send header 'Content-Type' when requesting this domain  
 *   **not_save_headers**: List of headers that should be ignored in generated file
 *   **skip_query_params**: List of query params that should be ignored in generated file
 *   **cache_request**: <<some_description>>

--- a/lib/tshield/configuration.rb
+++ b/lib/tshield/configuration.rb
@@ -100,6 +100,13 @@ module TShield
       domains[domain]['not_save_headers'] || []
     end
 
+    def send_header_content_type(domain)
+      if domains[domain]
+        return domains[domain]['send_header_content_type'] != false
+      end
+      return true
+    end
+
     def read_session_path
       session_path || '/sessions'
     end

--- a/lib/tshield/configuration.rb
+++ b/lib/tshield/configuration.rb
@@ -101,10 +101,8 @@ module TShield
     end
 
     def send_header_content_type(domain)
-      if domains[domain]
-        return domains[domain]['send_header_content_type'] != false
-      end
-      return true
+      return domains[domain]['send_header_content_type'] != false if domains[domain]
+      true
     end
 
     def read_session_path

--- a/lib/tshield/controllers/requests.rb
+++ b/lib/tshield/controllers/requests.rb
@@ -57,6 +57,9 @@ module TShield
             ip: request.ip
           }
 
+          treat_headers_by_domain(options, path)
+''
+
           if %w[POST PUT PATCH].include? method
             result = request.body.read.encode('UTF-8',
                                               invalid: :replace,
@@ -92,6 +95,11 @@ module TShield
           (configuration.get_headers(domain(path)) || {}).each do |source, destiny|
             options[:headers][destiny] = request.env[source] if request.env[source]
           end
+        end
+
+        def treat_headers_by_domain(options, path)
+          @send_header_content_type = configuration.send_header_content_type(domain(path))
+          options[:headers].delete('Content-Type') if !@send_header_content_type
         end
 
         def configuration

--- a/lib/tshield/controllers/requests.rb
+++ b/lib/tshield/controllers/requests.rb
@@ -58,7 +58,6 @@ module TShield
           }
 
           treat_headers_by_domain(options, path)
-''
 
           if %w[POST PUT PATCH].include? method
             result = request.body.read.encode('UTF-8',
@@ -77,7 +76,7 @@ module TShield
               configuration.get_excluded_headers(domain(path)).include?(key)
             end
           end
-          
+
           logger.info(
             "original=#{api_response.original} method=#{method} path=#{path} "\
             "content-type=#{request_content_type} "\
@@ -99,7 +98,7 @@ module TShield
 
         def treat_headers_by_domain(options, path)
           @send_header_content_type = configuration.send_header_content_type(domain(path))
-          options[:headers].delete('Content-Type') if !@send_header_content_type
+          options[:headers].delete('Content-Type') unless @send_header_content_type
         end
 
         def configuration

--- a/lib/tshield/version.rb
+++ b/lib/tshield/version.rb
@@ -5,7 +5,7 @@ module TShield
   class Version
     MAJOR = 0
     MINOR = 13
-    PATCH = 2
+    PATCH = 3
     PRE = 0
 
     class << self

--- a/spec/tshield/configuration_spec.rb
+++ b/spec/tshield/configuration_spec.rb
@@ -63,7 +63,7 @@ describe TShield::Configuration do
       it 'return nil if domain not found' do
         expect(@configuration.get_domain_for('/api/four')).to be_nil
       end
-    end 
+    end
 
     describe 'SO compatibility' do
       it 'should be compatible with windows when configuration is true' do
@@ -145,5 +145,5 @@ def generate_configuration_from_file(file)
   options_instance = double
   allow(options_instance).to receive(:configuration_file).and_return(file)
   allow(TShield::Options).to receive(:instance).and_return(options_instance)
-  return TShield::Configuration.singleton
+  TShield::Configuration.singleton
 end

--- a/spec/tshield/configuration_spec.rb
+++ b/spec/tshield/configuration_spec.rb
@@ -63,7 +63,7 @@ describe TShield::Configuration do
       it 'return nil if domain not found' do
         expect(@configuration.get_domain_for('/api/four')).to be_nil
       end
-    end
+    end 
 
     describe 'SO compatibility' do
       it 'should be compatible with windows when configuration is true' do
@@ -108,14 +108,42 @@ describe TShield::Configuration do
 
   context 'on config exists without grpc entry' do
     before :each do
-      options_instance = double
-      allow(options_instance).to receive(:configuration_file)
-        .and_return('spec/tshield/fixtures/config/tshield-without-grpc.yml')
-      allow(TShield::Options).to receive(:instance).and_return(options_instance)
-      @configuration = TShield::Configuration.singleton
+      @configuration = generate_configuration_from_file('spec/tshield/fixtures/config/tshield-without-grpc.yml')
+      TShield::Configuration.clear
     end
     it 'should set default value for port' do
       expect(@configuration.grpc).to eql('port' => 5678, 'proto_dir' => 'proto', 'services' => {})
     end
   end
+
+  context 'on config property request.domains.domain.send_header_content_type does not exists' do
+    before :each do
+      @configuration = generate_configuration_from_file('spec/tshield/fixtures/config/tshield-without-grpc.yml')
+      TShield::Configuration.clear
+    end
+    it 'should return send_header_content_type as true when property is not set' do
+      expect(@configuration.send_header_content_type('example.org')).to be true
+    end
+  end
+
+  context 'on config property request.domains.domain.send_header_content_type does exists' do
+    before :each do
+      TShield::Configuration.clear
+    end
+    it 'should return send_header_content_type as true when property is true' do
+      @configuration = generate_configuration_from_file('spec/tshield/fixtures/config/tshield-with-send-content-type-header.yml')
+      expect(@configuration.send_header_content_type('example.org')).to be true
+    end
+    it 'should return send_header_content_type as false when property is false' do
+      @configuration = generate_configuration_from_file('spec/tshield/fixtures/config/tshield-with-send-content-type-header_as_false.yml')
+      expect(@configuration.send_header_content_type('example.org')).to be false
+    end
+  end
+end
+
+def generate_configuration_from_file(file)
+  options_instance = double
+  allow(options_instance).to receive(:configuration_file).and_return(file)
+  allow(TShield::Options).to receive(:instance).and_return(options_instance)
+  return TShield::Configuration.singleton
 end

--- a/spec/tshield/controllers/requests_spec.rb
+++ b/spec/tshield/controllers/requests_spec.rb
@@ -58,3 +58,103 @@ describe TShield::Controllers::Requests do
     end
   end
 end
+
+describe TShield::Controllers::Requests do
+  before :each do
+    @configuration = double
+    allow(TShield::Configuration)
+      .to receive(:singleton).and_return(@configuration)
+    allow(@configuration).to receive(:get_before_filters).and_return([])
+    allow(@configuration).to receive(:not_save_headers).and_return([])
+    allow(@configuration).to receive(:get_after_filters).and_return([])
+    allow(@configuration).to receive(:get_headers).and_return([])
+    allow(@configuration).to receive(:request).and_return('timeout' => 10)
+    allow(@configuration).to receive(:get_name).and_return('example.org')
+    allow(@configuration).to receive(:get_domain_for).and_return('example.org')
+    allow(@configuration).to receive(:get_delay).and_return(0)
+    
+    
+    allow(TShield::Options).to receive_message_chain(:instance, :break?)
+    @mock_logger = double
+    @controller = MockController.new(@mock_logger)
+  end
+  context 'when send_header_content_type is false for a single domain' do
+    it 'should remove application/json header when making a request' do
+      
+        params = { 'captures' => ['/'] }
+
+        request = double
+        matcher = double
+        matched_response = double
+        allow(@configuration).to receive(:send_header_content_type).and_return(false)
+        
+        allow(request).to receive(:request_method).and_return('GET')
+        allow(request).to receive(:content_type).and_return('application/json')
+        allow(request).to receive(:ip).and_return('0.0.0.0')
+        allow(request).to receive(:env).and_return('QUERY_STRING' => 'a=b')
+        allow(TShield::RequestMatching).to receive(:new).and_return(matcher)
+        allow(matcher).to receive(:match_request).and_return(nil)
+        allow(TShield::RequestVCR).to receive(:new).and_return(matcher)
+        allow(matcher).to receive(:vcr_response).and_return(matched_response)
+        allow(matched_response).to receive(:original).and_return(false)
+        allow(matched_response).to receive(:status).and_return(200)
+        allow(matched_response).to receive(:headers).and_return({})
+        allow(matched_response).to receive(:body).and_return('')
+
+        allow(@mock_logger).to receive(:info)
+      
+        expect(TShield::RequestVCR).to receive(:new).with("/",{
+          call: 0,
+          headers: {},
+          ip: "0.0.0.0",
+          method: "GET",
+          raw_query: "a=b",
+          secondary_sessions: nil,
+          session: nil
+        })
+        @controller.treat(params, request, nil)
+
+        
+    end
+  end
+
+  context 'when send_header_content_type is true for a single domain' do
+    it 'should NOT remove application/json header when making a request' do
+      
+        params = { 'captures' => ['/'] }
+
+        request = double
+        matcher = double
+        matched_response = double
+        allow(@configuration).to receive(:send_header_content_type).and_return(true)
+        
+        allow(request).to receive(:request_method).and_return('GET')
+        allow(request).to receive(:content_type).and_return('application/json')
+        allow(request).to receive(:ip).and_return('0.0.0.0')
+        allow(request).to receive(:env).and_return('QUERY_STRING' => 'a=b')
+        allow(TShield::RequestMatching).to receive(:new).and_return(matcher)
+        allow(matcher).to receive(:match_request).and_return(nil)
+        allow(TShield::RequestVCR).to receive(:new).and_return(matcher)
+        allow(matcher).to receive(:vcr_response).and_return(matched_response)
+        allow(matched_response).to receive(:original).and_return(false)
+        allow(matched_response).to receive(:status).and_return(200)
+        allow(matched_response).to receive(:headers).and_return({})
+        allow(matched_response).to receive(:body).and_return('')
+
+        allow(@mock_logger).to receive(:info)
+      
+        expect(TShield::RequestVCR).to receive(:new).with("/",{
+          call: 0,
+          headers: {'Content-Type' => 'application/json'},
+          ip: "0.0.0.0",
+          method: "GET",
+          raw_query: "a=b",
+          secondary_sessions: nil,
+          session: nil
+        })
+        @controller.treat(params, request, nil)
+
+        
+    end
+  end
+end

--- a/spec/tshield/controllers/requests_spec.rb
+++ b/spec/tshield/controllers/requests_spec.rb
@@ -72,89 +72,81 @@ describe TShield::Controllers::Requests do
     allow(@configuration).to receive(:get_name).and_return('example.org')
     allow(@configuration).to receive(:get_domain_for).and_return('example.org')
     allow(@configuration).to receive(:get_delay).and_return(0)
-    
-    
+
+
     allow(TShield::Options).to receive_message_chain(:instance, :break?)
     @mock_logger = double
     @controller = MockController.new(@mock_logger)
   end
   context 'when send_header_content_type is false for a single domain' do
     it 'should remove application/json header when making a request' do
-      
-        params = { 'captures' => ['/'] }
+      params = { 'captures' => ['/'] }
+      request = double
+      matcher = double
+      matched_response = double
 
-        request = double
-        matcher = double
-        matched_response = double
-        allow(@configuration).to receive(:send_header_content_type).and_return(false)
-        
-        allow(request).to receive(:request_method).and_return('GET')
-        allow(request).to receive(:content_type).and_return('application/json')
-        allow(request).to receive(:ip).and_return('0.0.0.0')
-        allow(request).to receive(:env).and_return('QUERY_STRING' => 'a=b')
-        allow(TShield::RequestMatching).to receive(:new).and_return(matcher)
-        allow(matcher).to receive(:match_request).and_return(nil)
-        allow(TShield::RequestVCR).to receive(:new).and_return(matcher)
-        allow(matcher).to receive(:vcr_response).and_return(matched_response)
-        allow(matched_response).to receive(:original).and_return(false)
-        allow(matched_response).to receive(:status).and_return(200)
-        allow(matched_response).to receive(:headers).and_return({})
-        allow(matched_response).to receive(:body).and_return('')
+      allow(@configuration).to receive(:send_header_content_type).and_return(false)
+      allow(request).to receive(:request_method).and_return('GET')
+      allow(request).to receive(:content_type).and_return('application/json')
+      allow(request).to receive(:ip).and_return('0.0.0.0')
+      allow(request).to receive(:env).and_return('QUERY_STRING' => 'a=b')
+      allow(TShield::RequestMatching).to receive(:new).and_return(matcher)
+      allow(matcher).to receive(:match_request).and_return(nil)
+      allow(TShield::RequestVCR).to receive(:new).and_return(matcher)
+      allow(matcher).to receive(:vcr_response).and_return(matched_response)
+      allow(matched_response).to receive(:original).and_return(false)
+      allow(matched_response).to receive(:status).and_return(200)
+      allow(matched_response).to receive(:headers).and_return({})
+      allow(matched_response).to receive(:body).and_return('')
+      allow(@mock_logger).to receive(:info)
 
-        allow(@mock_logger).to receive(:info)
-      
-        expect(TShield::RequestVCR).to receive(:new).with("/",{
-          call: 0,
-          headers: {},
-          ip: "0.0.0.0",
-          method: "GET",
-          raw_query: "a=b",
-          secondary_sessions: nil,
-          session: nil
-        })
-        @controller.treat(params, request, nil)
-
-        
+      expect(TShield::RequestVCR).to receive(:new).with("/",{
+        call: 0,
+        headers: {},
+        ip: "0.0.0.0",
+        method: "GET",
+        raw_query: "a=b",
+        secondary_sessions: nil,
+        session: nil
+      })
+      @controller.treat(params, request, nil)
     end
   end
 
   context 'when send_header_content_type is true for a single domain' do
     it 'should NOT remove application/json header when making a request' do
-      
-        params = { 'captures' => ['/'] }
+      params = { 'captures' => ['/'] }
+      request = double
+      matcher = double
+      matched_response = double
 
-        request = double
-        matcher = double
-        matched_response = double
-        allow(@configuration).to receive(:send_header_content_type).and_return(true)
-        
-        allow(request).to receive(:request_method).and_return('GET')
-        allow(request).to receive(:content_type).and_return('application/json')
-        allow(request).to receive(:ip).and_return('0.0.0.0')
-        allow(request).to receive(:env).and_return('QUERY_STRING' => 'a=b')
-        allow(TShield::RequestMatching).to receive(:new).and_return(matcher)
-        allow(matcher).to receive(:match_request).and_return(nil)
-        allow(TShield::RequestVCR).to receive(:new).and_return(matcher)
-        allow(matcher).to receive(:vcr_response).and_return(matched_response)
-        allow(matched_response).to receive(:original).and_return(false)
-        allow(matched_response).to receive(:status).and_return(200)
-        allow(matched_response).to receive(:headers).and_return({})
-        allow(matched_response).to receive(:body).and_return('')
+      allow(@configuration).to receive(:send_header_content_type).and_return(true)
+      allow(request).to receive(:request_method).and_return('GET')
+      allow(request).to receive(:content_type).and_return('application/json')
+      allow(request).to receive(:ip).and_return('0.0.0.0')
+      allow(request).to receive(:env).and_return('QUERY_STRING' => 'a=b')
+      allow(TShield::RequestMatching).to receive(:new).and_return(matcher)
+      allow(matcher).to receive(:match_request).and_return(nil)
+      allow(TShield::RequestVCR).to receive(:new).and_return(matcher)
+      allow(matcher).to receive(:vcr_response).and_return(matched_response)
+      allow(matched_response).to receive(:original).and_return(false)
+      allow(matched_response).to receive(:status).and_return(200)
+      allow(matched_response).to receive(:headers).and_return({})
+      allow(matched_response).to receive(:body).and_return('')
+      allow(@mock_logger).to receive(:info)
 
-        allow(@mock_logger).to receive(:info)
-      
-        expect(TShield::RequestVCR).to receive(:new).with("/",{
-          call: 0,
-          headers: {'Content-Type' => 'application/json'},
-          ip: "0.0.0.0",
-          method: "GET",
-          raw_query: "a=b",
-          secondary_sessions: nil,
-          session: nil
-        })
-        @controller.treat(params, request, nil)
+      expect(TShield::RequestVCR).to receive(:new).with("/",{
+        call: 0,
+        headers: {'Content-Type' => 'application/json'},
+        ip: "0.0.0.0",
+        method: "GET",
+        raw_query: "a=b",
+        secondary_sessions: nil,
+        session: nil
+      })
 
-        
+
+      @controller.treat(params, request, nil)
     end
   end
 end

--- a/spec/tshield/fixtures/config/tshield-with-send-content-type-header.yml
+++ b/spec/tshield/fixtures/config/tshield-with-send-content-type-header.yml
@@ -1,0 +1,18 @@
+---
+request:
+  timeout: 0
+domains:
+  'example.org':
+    name: 'example.org'
+    send_header_content_type: true
+    filters:
+      - 'ExampleFilter'
+    paths:
+      - '/api/one'
+      - '/api/two'
+    skip_query_params:
+      - 'a'
+  'example.com':
+    name: 'example.com'
+    paths:
+      - '/api/three'

--- a/spec/tshield/fixtures/config/tshield-with-send-content-type-header_as_false.yml
+++ b/spec/tshield/fixtures/config/tshield-with-send-content-type-header_as_false.yml
@@ -1,0 +1,18 @@
+---
+request:
+  timeout: 0
+domains:
+  'example.org':
+    name: 'example.org'
+    send_header_content_type: false
+    filters:
+      - 'ExampleFilter'
+    paths:
+      - '/api/one'
+      - '/api/two'
+    skip_query_params:
+      - 'a'
+  'example.com':
+    name: 'example.com'
+    paths:
+      - '/api/three'


### PR DESCRIPTION
## Description
When calling some services using TShield, the service does not accepts Header["Content-Type"]
As this header is sent by default, this improvement solve this and make integration with this kind of service
## Type of change

Please delete options that are not relevant.

*   [ ] Bug fix
*   [X] New feature
*   [ ] This change requires a documentation update

## How Has This Been Tested
It was tested with wsdl services and worked just fine
As it is under domains, only requests for that specific domain will 'Content-Type' header will be removed
It was tested also on unit tests